### PR TITLE
add: link to replit run

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "nodejs"
+run = "npx http-server"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # Under
+
+[![run on repl.it](http://repl.it/badge/github/westoncb/under-game)](https://repl.it/github/westoncb/under-game)
+
 Under is a minimal game written in JavaScript and GLSL with procedural graphics produced mostly by noise, signed distance functions, and [boolean/space-folding operators](http://mercury.sexy/hg_sdf/) applied to those functions. The codebase is small and fairly well-documented.
 
 - [Play here!](http://symbolflux.com/under) (Mobile not yet supported; just shows a video)


### PR DESCRIPTION
i think it would be pretty cool to let people see how this code works (and edit / preview the program) right in their browser, without any manual downloads or installation. i'm thinking we can add a 'run on repl.it' button, which redirects to something like [this](https://repl.it/@eankeen/run-under-game):

![image](https://i.imgur.com/t8gLDlW.png)
